### PR TITLE
fix: import usage check could pass on a less-specific import

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -289,7 +289,7 @@ func TestParseFile(t *testing.T) {
 		fmt.Printf("Parsing file: %v \n", tt.file)
 		pf, err := ParseFile(tt.file)
 		if err != nil {
-			t.Errorf("%v", err.Error())
+			t.Errorf("%s: %v", tt.file, err.Error())
 			continue
 		}
 

--- a/verifier.go
+++ b/verifier.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 type protoFileOracle struct {
@@ -465,9 +466,34 @@ func validateRPCDataType(
 	return nil
 }
 
+func getPackageName(datatypeName string) string {
+	parts := strings.Split(datatypeName, ".")
+	if len(parts) == 1 {
+		return "" // no package name
+	}
+
+	offset := 0
+	for i, p := range parts {
+		if unicode.IsUpper(rune(p[0])) {
+			break
+		}
+
+		offset += len(p)
+		if i > 0 {
+			offset += 1 // also account for the '.'
+		}
+	}
+
+	return datatypeName[:offset]
+}
+
 func isDatatypeInSamePackage(datatypeName string, packageNames []string) (bool, string) {
+	dtPkg := getPackageName(datatypeName)
+	if len(dtPkg) == 0 {
+		return true, ""
+	}
 	for _, pkg := range packageNames {
-		if strings.HasPrefix(datatypeName, pkg+".") {
+		if pkg == dtPkg {
 			return false, pkg
 		}
 	}

--- a/verifier.go
+++ b/verifier.go
@@ -466,6 +466,12 @@ func validateRPCDataType(
 	return nil
 }
 
+// Gets the most-specific package name for the given type name.
+//
+// In order to support nested-message imports like `foo.bar.BazMessage.InnerMessage`
+// the "most specific" check uses the last package segment that is
+// not uppercased as the last package segment. This aligns with
+// naming conventions laid out by Google and most common usage.
 func getPackageName(datatypeName string) string {
 	parts := strings.Split(datatypeName, ".")
 	if len(parts) == 1 {


### PR DESCRIPTION
For example, the datatype `foo.bar.Baz` would pass the import
check for either `foo` or `foo.bar`.

This becomes an issue because the `[]string packageNames` is
non-determinstically ordered and can cause flaky checks. When the
less-specific import is used for a more-specific datatype, the
more-specific import "becomes" unused later in the check.

This change means that an import is only considered used if
one or more types use the fully qualified import (everything up
to the most-specific '.' separator).

In order to support nested-message imports like:

    foo.bar.BazMessage.InnerMessage

the "most specific" check uses the last package segment that is
not uppercased as the last package segment. This aligns with
naming conventions laid out by Google and most common usage.