### PR TITLE
Record the enums found in all proto files for later access

### DIFF
--- a/elements.go
+++ b/elements.go
@@ -141,4 +141,5 @@ type ProtoFile struct {
 	Messages           []MessageElement
 	Services           []ServiceElement
 	ExtendDeclarations []ExtendElement
+	Oracles            map[string]ProtoFileOracle
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/aristanetworks/pbparser
 
-go 1.12
+go 1.19
+
+require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -437,3 +439,21 @@ var (
 	tab  = indent(2)
 	tab2 = indent(4)
 )
+
+func Test_External_Enum(t *testing.T) {
+	file := "./resources/service.proto"
+
+	// invoke ParseFile() API to parse the file
+	pf, err := ParseFile(file)
+	if err != nil {
+		t.Fatalf("Unable to parse proto file: %v \n", err)
+	}
+
+	// print attributes of the returned datastructure
+	fmt.Printf("PackageName: %v, Syntax: %v\n", pf.PackageName, pf.Syntax)
+	fmt.Printf("Oracles: %v", pf.Oracles)
+
+	oracle, ok := pf.Oracles["publicx"]
+	assert.True(t, ok)
+	assert.True(t, oracle.HasEnum("publicx.StatusEnum"))
+}


### PR DESCRIPTION
Some tooling we use internally requires that we can validate against enums found not just in the current proto file, but also in imported proto files. If we retain the oracles generated during parse time for all proto files, we can refer back to them at a later validation time in our code to ensure the externally referred-to enum exists somewhere in the file dependencies.

Added a test to show the usage.