### PR TITLE
pbparser/parser: fix multiline docstring parse issue

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1058,6 +1058,14 @@ func (p *parser) readMultiLineComment() string {
 func (p *parser) readSingleLineComment() string {
 	str := strings.TrimSpace(p.readUntilNewline())
 	for {
+		// If the next character is \n, then it implies we have
+		// an empty line. Ignore the comments before the empty line.
+		if c := p.read(); c == '\n' {
+			str = ""
+			continue
+		} else {
+			p.unread()
+		}
 		p.skipWhitespace()
 		if c := p.read(); c != '/' {
 			p.unread()
@@ -1067,7 +1075,11 @@ func (p *parser) readSingleLineComment() string {
 			p.unread()
 			break
 		}
-		str += " " + strings.TrimSpace(p.readUntilNewline())
+		if len(str) > 0 {
+			str += " " + strings.TrimSpace(p.readUntilNewline())
+		} else {
+			str = strings.TrimSpace(p.readUntilNewline())
+		}
 	}
 	return str
 }

--- a/parser.go
+++ b/parser.go
@@ -1061,8 +1061,7 @@ func (p *parser) readSingleLineComment() string {
 		// If the next character is \n, then it implies we have
 		// an empty line. Ignore the comments before the empty line.
 		if c := p.read(); c == '\n' {
-			str = ""
-			continue
+			break
 		} else {
 			p.unread()
 		}
@@ -1075,11 +1074,7 @@ func (p *parser) readSingleLineComment() string {
 			p.unread()
 			break
 		}
-		if len(str) > 0 {
-			str += " " + strings.TrimSpace(p.readUntilNewline())
-		} else {
-			str = strings.TrimSpace(p.readUntilNewline())
-		}
+		str += " " + strings.TrimSpace(p.readUntilNewline())
 	}
 	return str
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -330,6 +330,38 @@ func TestParseFile(t *testing.T) {
 	}
 }
 
+func TestComments(t *testing.T) {
+	var tests = []struct {
+		file             string
+		expectedComments []string
+	}{
+		{
+			file: "./resources/comments.proto",
+			expectedComments: []string{
+				"Both lines should be kept here Foo",
+				"Bar",
+				"Bar2",
+				"ReverseBar",
+				"The second multiline comment",
+			},
+		},
+	}
+	for _, tt := range tests {
+		fmt.Printf("Parsing file: %v \n", tt.file)
+		pf, err := ParseFile(tt.file)
+		if err != nil {
+			t.Errorf("%s: %v", tt.file, err.Error())
+			continue
+		}
+		for i, m := range pf.Messages {
+			if m.Documentation != tt.expectedComments[i] {
+				t.Errorf("expected comment: %s, actual comment: %s",
+					tt.expectedComments[i], m.Documentation)
+			}
+		}
+	}
+}
+
 func printMessage(m *MessageElement, prefix string) {
 	fmt.Println(prefix + "Message: " + m.Name)
 	fmt.Println(prefix + "QualifiedName: " + m.QualifiedName)

--- a/resources/comments.proto
+++ b/resources/comments.proto
@@ -1,0 +1,42 @@
+/* Docstring beginning of file
+*/
+syntax = "proto3";
+package commentspkg;
+
+// Both lines should be kept here
+// Foo
+message Foo {
+}
+
+// This line should be removed during parsing
+
+// Bar
+message Bar {
+}
+
+/*
+Testing multiline comment with single line comment
+*/
+
+// Bar2
+message Bar2 {
+}
+
+// Testing single line comment with multiline comment
+
+/*
+ReverseBar
+*/
+message ReverseBar {
+}
+
+/*   
+Two multiline comments for this test case
+test
+*/
+
+/*
+The second multiline comment
+*/
+message TwoMultiLine {
+}


### PR DESCRIPTION
The parser sees multiline docstring as one single block of documentation, even when the docstring is separated by empty lines. After this change, only the last block of docstring will be considered after parsing.